### PR TITLE
Add student ID support for user identification (issue #29)

### DIFF
--- a/lms/backend/canvas/model.py
+++ b/lms/backend/canvas/model.py
@@ -104,6 +104,9 @@ def course_user(backend: lms.model.backend.APIBackend, data: typing.Dict[str, ty
     # Modify specific arguments before sending them to super.
     data['id'] = lms.util.parse.required_string(data.get('id', None), 'id')
 
+    # Extract student ID from Canvas (called sis_user_id in the API).
+    data['student_id'] = data.get('sis_user_id', None)
+
     # Canvas sometimes has email under different fields.
     if ((data.get('email', None) is None) or (len(data.get('email', '')) == 0)):
         data['email'] = data.get('login_id', None)

--- a/lms/model/users.py
+++ b/lms/model/users.py
@@ -11,11 +11,14 @@ class UserQuery(lms.model.query.BaseQuery):
      - LMS User ID (`id`)
      - Email (`email`)
      - Full Name (`name`)
+     - Student ID (`student_id`)
      - f"{email} ({id})"
      - f"{name} ({id})"
+     - f"{name} [{student_id}] ({id})"
     """
 
     _include_email = True
+    _include_student_id = True
 
 class ResolvedUserQuery(lms.model.query.ResolvedBaseQuery, UserQuery):
     """
@@ -23,11 +26,13 @@ class ResolvedUserQuery(lms.model.query.ResolvedBaseQuery, UserQuery):
     """
 
     _include_email = True
+    _include_student_id = True
 
     def __init__(self,
             user: 'ServerUser',
             **kwargs: typing.Any) -> None:
-        super().__init__(id = user.id, name = user.name, email = user.email, **kwargs)
+        super().__init__(id = user.id, name = user.name, email = user.email,
+                student_id = user.student_id, **kwargs)
 
 class CourseRole(enum.Enum):
     """
@@ -49,13 +54,14 @@ class ServerUser(lms.model.base.BaseType):
     A user associated with an LMS server.
     """
 
-    CORE_FIELDS = ['id', 'name', 'email']
+    CORE_FIELDS = ['id', 'name', 'email', 'student_id']
     """ The common fields shared across backends for this type. """
 
     def __init__(self,
             id: typing.Union[str, int, None] = None,
             email: typing.Union[str, None] = None,
             name: typing.Union[str, None] = None,
+            student_id: typing.Union[str, None] = None,
             **kwargs: typing.Any) -> None:
         super().__init__(**kwargs)
 
@@ -70,6 +76,9 @@ class ServerUser(lms.model.base.BaseType):
 
         self.email: typing.Union[str, None] = email
         """ The email address of this user. """
+
+        self.student_id: typing.Union[str, None] = student_id
+        """ The student ID (also known as SIS ID) for this user. """
 
     def to_query(self) -> ResolvedUserQuery:
         """ Get a query representation of this user. """


### PR DESCRIPTION
Hey! @eriq-augustine. This PR adds support for student IDs (issue #29).

## What I changed

I added a `student_id` field so users can be identified by their student/SIS ID, not just email or LMS ID. The main changes are:

- Added `student_id` to the user model in [users.py](cci:7://file:///c:/Users/surya/OneDrive/Desktop/LMS%20toolkit/lms-toolkit/lms/model/users.py:0:0-0:0)
- Updated the query system in [query.py](cci:7://file:///c:/Users/surya/OneDrive/Desktop/LMS%20toolkit/lms-toolkit/lms/model/query.py:0:0-0:0) to match and parse student IDs
- Pulled `sis_user_id` from the Canvas API in [canvas/model.py](cci:7://file:///c:/Users/surya/OneDrive/Desktop/LMS%20toolkit/lms-toolkit/lms/backend/canvas/model.py:0:0-0:0)

## How it works

Users now show up like: `John Doe [98765432] (12345)` where the brackets have the student ID and parentheses have the LMS ID.

The parsing also works backwards - if you give it `"John Doe [98765432] (12345)"` it will correctly extract all the parts.

## Notes

- Student ID is optional so it won't break anything for users who don't have one
- Old formats like `"John Doe (12345)"` still work fine
- This should help with issue #13 (gradebook exports)

Let me know if anything needs changes! Thankyou so much.