### PR TITLE
Support for Student IDs

### DIFF
--- a/lms/backend/blackboard/model.py
+++ b/lms/backend/blackboard/model.py
@@ -49,6 +49,7 @@ def course_user(data: typing.Dict[str, typing.Any]) -> lms.model.users.CourseUse
         id = parse_id(user['id']),
         name = user['name']['given'],
         email = user['contact']['email'],
+        student_id = user.get('studentId', None),
         raw_role = data['courseRoleId'],
         role = COURSE_ROLE_MAPPING.get(data['courseRoleId'], None),
     )

--- a/lms/backend/canvas/model.py
+++ b/lms/backend/canvas/model.py
@@ -104,6 +104,10 @@ def course_user(backend: lms.model.backend.APIBackend, data: typing.Dict[str, ty
     # Modify specific arguments before sending them to super.
     data['id'] = lms.util.parse.required_string(data.get('id', None), 'id')
 
+    # Extract student ID from Canvas SIS user ID.
+    if (data.get('student_id', None) is None):
+        data['student_id'] = data.get('sis_user_id', None)
+
     # Canvas sometimes has email under different fields.
     if ((data.get('email', None) is None) or (len(data.get('email', '')) == 0)):
         data['email'] = data.get('login_id', None)

--- a/lms/model/base_test.py
+++ b/lms/model/base_test.py
@@ -57,6 +57,7 @@ class TestBaseType(edq.testing.unittest.BaseTest):
                     'email': None,
                     'id': '123',
                     'name': 'Alice',
+                    'student_id': None,
                     'extra': 'abc',
                 },
             ),
@@ -194,6 +195,7 @@ class TestBaseType(edq.testing.unittest.BaseTest):
                     'id: 123',
                     'name: Alice',
                     'email: ',
+                    'student_id: ',
                     'extra: abc',
                 ],
             ),
@@ -294,6 +296,7 @@ class TestBaseType(edq.testing.unittest.BaseTest):
                 [[
                     '123',
                     'Alice',
+                    '',
                     '',
                     'abc',
                 ]],

--- a/lms/model/query_test.py
+++ b/lms/model/query_test.py
@@ -1,6 +1,7 @@
 import edq.testing.unittest
 
 import lms.model.query
+import lms.model.users
 
 class TestQuery(edq.testing.unittest.BaseTest):
     """ Test queries. """
@@ -236,6 +237,82 @@ class TestQuery(edq.testing.unittest.BaseTest):
             (
                 lms.model.query.BaseQuery(id = '123', name = 'name', email = 'email@test.edulinq.org'),
                 lms.model.query.BaseQuery(id = '999', name = 'ZZZZ', email = 'ZZZZZ@test.edulinq.org'),
+                False,
+            ),
+        ]
+
+        for (i, test_case) in enumerate(test_cases):
+            (query, target, expected) = test_case
+
+            with self.subTest(msg = f"Case {i} ('{query}' vs '{target}'):"):
+                actual = query.match(target)
+                self.assertEqual(expected, actual)
+
+    def test_match_user_query_student_id(self):
+        """ Test user query matching with student_id. """
+
+        # [(query, target, expected), ...]
+        test_cases = [
+            # Match by name against target name
+            (
+                lms.model.users.UserQuery(name = 'Alice'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice', student_id = 'S001'),
+                True,
+            ),
+
+            # Match by name against target student_id
+            (
+                lms.model.users.UserQuery(name = 'S001'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice', student_id = 'S001'),
+                True,
+            ),
+
+            # Name does not match name or student_id
+            (
+                lms.model.users.UserQuery(name = 'ZZZZ'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice', student_id = 'S001'),
+                False,
+            ),
+
+            # No student_id on target, query by name should still match name
+            (
+                lms.model.users.UserQuery(name = 'Alice'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice'),
+                True,
+            ),
+
+            # Match name against student_id when name is None on target
+            (
+                lms.model.users.UserQuery(name = 'S001'),
+                lms.model.users.ServerUser(id = '123', student_id = 'S001'),
+                True,
+            ),
+
+            # Name matches neither name nor student_id (no student_id on target)
+            (
+                lms.model.users.UserQuery(name = 'S001'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice'),
+                False,
+            ),
+
+            # Match by email with student_id present
+            (
+                lms.model.users.UserQuery(email = 'alice@test.org'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice', email = 'alice@test.org', student_id = 'S001'),
+                True,
+            ),
+
+            # Match by ID with student_id present
+            (
+                lms.model.users.UserQuery(id = '123'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice', student_id = 'S001'),
+                True,
+            ),
+
+            # ID mismatch, even though name matches student_id
+            (
+                lms.model.users.UserQuery(id = '999', name = 'S001'),
+                lms.model.users.ServerUser(id = '123', name = 'Alice', student_id = 'S001'),
                 False,
             ),
         ]


### PR DESCRIPTION
Closes #29.

This PR adds support for student IDs.
Blackboard: https://devportal-docstore.s3.amazonaws.com/learn-swagger.json
Canvas: https://developerdocs.instructure.com/services/canvas/resources/users

Feel free to give any feedback!