### PR TITLE
 Add optional header support for TSV input files

### DIFF
--- a/lms/backend/testdata/cli/data/scores/course101_hw0_emptyvalue.txt
+++ b/lms/backend/testdata/cli/data/scores/course101_hw0_emptyvalue.txt
@@ -1,2 +1,2 @@
 User	Score
-course-student@test.edulinq.org	
+course-student@test.edulinq.org

--- a/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_emptyvalue.txt
+++ b/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_emptyvalue.txt
@@ -6,6 +6,7 @@
         "--skip-rows", "1",
         "__DATA_DIR__(scores/course101_hw0_emptyvalue.txt)",
     ],
+    "error": true,
 }
 ---
-Uploaded 1 Scores
+builtins.ValueError: Line 2 (effective 2): Has the incorrect number of values. Expecting 2-3, found 1.

--- a/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_longline.txt
+++ b/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_longline.txt
@@ -9,4 +9,4 @@
     "error": true,
 }
 ---
-builtins.ValueError: File '__DATA_DIR__(scores/course101_hw0_longline.txt)' line 2 has the incorrect number of values. Expecting 2-3, found 4.
+builtins.ValueError: Line 2 (effective 2): Has the incorrect number of values. Expecting 2-3, found 4.

--- a/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_nan.txt
+++ b/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_nan.txt
@@ -9,4 +9,4 @@
     "error": true,
 }
 ---
-builtins.ValueError: File '__DATA_DIR__(scores/course101_hw0_nan.txt)' line 2 has a score that cannot be converted to a number: 'ZZZ'.
+builtins.ValueError: Line 2 (effective 2): Has a score that cannot be converted to a number: 'ZZZ'.

--- a/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_shortline.txt
+++ b/lms/backend/testdata/cli/tests/courses/assignments/scores/upload_course101_hw0_shortline.txt
@@ -9,4 +9,4 @@
     "error": true,
 }
 ---
-builtins.ValueError: File '__DATA_DIR__(scores/course101_hw0_shortline.txt)' line 2 has the incorrect number of values. Expecting 2-3, found 1.
+builtins.ValueError: Line 2 (effective 2): Has the incorrect number of values. Expecting 2-3, found 1.

--- a/lms/cli/courses/assignments/scores/upload.py
+++ b/lms/cli/courses/assignments/scores/upload.py
@@ -7,14 +7,13 @@ import ast
 import sys
 import typing
 
-import edq.util.dirent
-
 import lms.backend.instance
 import lms.cli.common
 import lms.cli.parser
 import lms.model.backend
 import lms.model.scores
 import lms.model.users
+import lms.util.tsv
 
 def run_cli(args: argparse.Namespace) -> int:
     """ Run the CLI. """
@@ -43,49 +42,60 @@ def run_cli(args: argparse.Namespace) -> int:
 def _load_scores(
         backend: lms.model.backend.APIBackend,
         path: str,
-        skip_rows: bool,
+        skip_rows: int,
         ) -> typing.Dict[lms.model.users.UserQuery, lms.model.scores.ScoreFragment]:
+    """ Load scores from a TSV file. """
+
+    tsv = lms.util.tsv.load_tsv_table(
+        path,
+        ['user', 'score', 'comment'],
+        required_columns = ['user', 'score'],
+        skip_rows = skip_rows,
+    )
+
     scores = {}
 
-    with open(path, 'r', encoding = edq.util.dirent.DEFAULT_ENCODING) as file:
-        lineno = 0
-        real_rows = 0
-        for line in file:
-            lineno += 1
+    user_index = tsv.header_map['user']
+    score_index = tsv.header_map['score']
+    comment_index = tsv.header_map['comment']
 
-            if (line.strip() == ''):
-                continue
+    if (user_index is None or score_index is None):
+        raise ValueError(f"File '{path}' is missing required columns 'user' and/or 'score'.")
 
-            real_rows += 1
+    max_required_index = max(user_index, score_index)
 
-            if (real_rows <= skip_rows):
-                continue
+    for row in tsv.rows:
+        if (tsv.headers is None):
+            if (len(row.parts) not in [2, 3]):
+                row.raise_error(f"Has the incorrect number of values. Expecting 2-3, found {len(row.parts)}.")
+        else:
+            if (len(row.parts) <= max_required_index):
+                row.raise_error(f"Has the incorrect number of values. Expecting 2-3, found {len(row.parts)}.")
 
-            parts = [part.strip() for part in line.split("\t")]
-            if (len(parts) not in [2, 3]):
-                raise ValueError(f"File '{path}' line {lineno} has the incorrect number of values. Expecting 2-3, found {len(parts)}.")
+        user_value = row.parts[user_index]
+        user_query = backend.parse_user_query(user_value)
+        if (user_query is None):
+            row.raise_error(f"Has a user query that could not be parsed: '{user_value}'.")
 
-            user_query = backend.parse_user_query(parts[0])
-            if (user_query is None):
-                raise ValueError(f"File '{path}' line {lineno} has a user query that could not be parsed: '{parts[0]}'.")
+        score_value = row.parts[score_index]
+        score = None
+        if (score_value != ''):
+            try:
+                score = float(ast.literal_eval(score_value))
+            except Exception:
+                row.raise_error(f"Has a score that cannot be converted to a number: '{score_value}'.")  # pylint: disable=raise-missing-from
 
-            score = None
-            if (parts[1] != ''):
-                try:
-                    score = float(ast.literal_eval(parts[1]))
-                except Exception:
-                    raise ValueError(f"File '{path}' line {lineno} has a score that cannot be converted to a number: '{parts[1]}'.")  # pylint: disable=raise-missing-from
+        comment = None
+        if ((comment_index is not None) and (comment_index < len(row.parts))):
+            comment = row.parts[comment_index] or None
 
-            comment = None
-            if (len(parts) == 3):
-                comment = parts[2]
-
-            scores[user_query] = lms.model.scores.ScoreFragment(score = score, comment = comment)
+        scores[user_query] = lms.model.scores.ScoreFragment(score = score, comment = comment)
 
     return scores
 
 def main() -> int:
     """ Get a parser, parse the args, and call run. """
+
     return run_cli(_get_parser().parse_args())
 
 def _get_parser() -> argparse.ArgumentParser:

--- a/lms/cli/courses/groupsets/memberships/common.py
+++ b/lms/cli/courses/groupsets/memberships/common.py
@@ -1,45 +1,46 @@
 import typing
 
-import edq.util.dirent
-
 import lms.model.backend
 import lms.model.groups
+import lms.util.tsv
 
 def load_group_memberships(
         backend: lms.model.backend.APIBackend,
         path: str,
-        skip_rows: bool,
+        skip_rows: int,
         ) -> typing.List[lms.model.groups.GroupMembership]:
     """ Read a group membership TSV file. """
 
+    tsv = lms.util.tsv.load_tsv_table(
+        path,
+        ['group', 'user'],
+        required_columns = ['group', 'user'],
+        skip_rows = skip_rows,
+    )
+
     memberships: typing.List[lms.model.groups.GroupMembership] = []
 
-    with open(path, 'r', encoding = edq.util.dirent.DEFAULT_ENCODING) as file:
-        lineno = 0
-        real_rows = 0
-        for line in file:
-            lineno += 1
+    if (tsv.header_map['group'] is None or tsv.header_map['user'] is None):
+        raise ValueError(f"File '{path}' is missing required columns 'group' and/or 'user'.")
 
-            if (line.strip() == ''):
-                continue
+    max_required_index = max(tsv.header_map['group'], tsv.header_map['user'])
 
-            real_rows += 1
+    for row in tsv.rows:
+        if (tsv.headers is None):
+            if (len(row.parts) != 2):
+                row.raise_error(f"Has the incorrect number of values. Expecting 2, found {len(row.parts)}.")
+        else:
+            if (len(row.parts) <= max_required_index):
+                row.raise_error(f"Has the incorrect number of values. Expecting 2, found {len(row.parts)}.")
 
-            if (real_rows <= skip_rows):
-                continue
+        group_query = backend.parse_group_query(row.parts[tsv.header_map['group']])
+        if (group_query is None):
+            row.raise_error(f"Has a group query that could not be parsed: '{row.parts[tsv.header_map['group']]}'.")
 
-            parts = [part.strip() for part in line.split("\t")]
-            if (len(parts) != 2):
-                raise ValueError(f"File '{path}' line {lineno} has the incorrect number of values. Expecting 2, found {len(parts)}.")
+        user_query = backend.parse_user_query(row.parts[tsv.header_map['user']])
+        if (user_query is None):
+            row.raise_error(f"Has a user query that could not be parsed: '{row.parts[tsv.header_map['user']]}'.")
 
-            group_query = backend.parse_group_query(parts[0])
-            if (group_query is None):
-                raise ValueError(f"File '{path}' line {lineno} has a group query that could not be parsed: '{parts[0]}'.")
-
-            user_query = backend.parse_user_query(parts[1])
-            if (user_query is None):
-                raise ValueError(f"File '{path}' line {lineno} has a user query that could not be parsed: '{parts[1]}'.")
-
-            memberships.append(lms.model.groups.GroupMembership(group = group_query, user = user_query))
+        memberships.append(lms.model.groups.GroupMembership(group = group_query, user = user_query))
 
     return memberships

--- a/lms/util/tsv.py
+++ b/lms/util/tsv.py
@@ -1,0 +1,171 @@
+"""
+Utility for reading and parsing TSV (tab-separated values) files.
+"""
+
+import typing
+
+import edq.util.dirent
+
+class TSVRow:
+    """ A single row from a TSV file. """
+
+    def __init__(
+            self,
+            parts: typing.List[str],
+            lineno: int,
+            effective_lineno: int,
+            ) -> None:
+        self.parts = parts
+        self.lineno = lineno
+        self.effective_lineno = effective_lineno
+
+    def raise_error(self, message: str) -> typing.NoReturn:
+        """ Raise a ValueError with this row's line context prepended. """
+
+        raise ValueError(
+            f"Line {self.lineno}"
+            f" (effective {self.effective_lineno}): {message}"
+        )
+
+class TSVFile:
+    """ A parsed TSV file with header metadata and a column index map. """
+
+    def __init__(
+            self,
+            headers: typing.Union[typing.List[str], None],
+            rows: typing.List[TSVRow],
+            header_map: typing.Dict[str, typing.Union[int, None]],
+            ) -> None:
+        self.headers = headers
+        self.rows = rows
+        self.header_map = header_map
+
+    def to_dicts(self) -> typing.List[typing.Dict[str, str]]:
+        """ Convert the TSV rows to a list of dicts keyed by column name. """
+
+        result = []
+        for row in self.rows:
+            entry = {}
+            for name, index in self.header_map.items():
+                entry[name] = _resolve_part(row, index)
+            result.append(entry)
+
+        return result
+
+def _resolve_part(row: TSVRow, index: typing.Union[int, None]) -> str:
+    """ Return the part at index, or empty string if absent or out of range. """
+
+    if (index is None):
+        return ''
+
+    if (index < len(row.parts)):
+        return row.parts[index]
+
+    return ''
+
+def parse_tsv_rows(path: str) -> typing.List[TSVRow]:
+    """ Parse a TSV file into raw rows, skipping blanks. Parts are stripped. """
+
+    content = edq.util.dirent.read_file(path)
+    rows = []
+    effective_lineno = 0
+
+    for lineno, line in enumerate(content.splitlines(), start = 1):
+        if (line.strip() == ''):
+            continue
+
+        effective_lineno += 1
+        parts = [part.strip() for part in line.split('\t')]
+
+        rows.append(TSVRow(
+            parts = parts,
+            lineno = lineno,
+            effective_lineno = effective_lineno
+        ))
+
+    return rows
+
+def load_tsv_table(
+        path: str,
+        expected_columns: typing.List[str],
+        required_columns: typing.Union[typing.List[str], None] = None,
+        skip_rows: int = 0,
+        interpret_headers: bool = True,
+        ) -> TSVFile:
+    """ Interpret a TSV file's rows into a TSVFile with column mapping. """
+
+    if (len(expected_columns) == 0):
+        raise ValueError("expected_columns must not be empty.")
+
+    if (skip_rows < 0):
+        raise ValueError("skip_rows must be non-negative.")
+
+    if (required_columns is not None):
+        expected_lower = {col.lower() for col in expected_columns}
+        unknown = []
+        for c in required_columns:
+            if (c.lower() not in expected_lower):
+                unknown.append(c)
+
+        if (len(unknown) > 0):
+            raise ValueError(
+                f"required_columns contains names not in expected_columns:"
+                f" {sorted(unknown)}"
+            )
+
+    raw_rows = parse_tsv_rows(path)
+    data_rows = raw_rows[skip_rows:]
+
+    default_map: typing.Dict[str, typing.Union[int, None]] = {}
+    for i, name in enumerate(expected_columns):
+        default_map[name] = i
+
+    if (len(data_rows) == 0):
+        return TSVFile(headers = None, rows = [], header_map = default_map)
+
+    if (interpret_headers):
+        header_map = _match_header_row(
+            data_rows[0].parts,
+            expected_columns,
+            required_columns or expected_columns,
+        )
+
+        if (header_map is not None):
+            header_parts = data_rows[0].parts
+            data_rows = data_rows[1:]
+
+            return TSVFile(
+                headers = header_parts,
+                rows = data_rows,
+                header_map = header_map
+            )
+
+    return TSVFile(headers = None, rows = data_rows, header_map = default_map)
+
+def _match_header_row(
+        parts: typing.List[str],
+        expected_columns: typing.List[str],
+        required_columns: typing.List[str],
+        ) -> typing.Union[typing.Dict[str, typing.Union[int, None]], None]:
+    """ Return a column index map if all required columns match, else None. """
+
+    normalized_expected = {col.lower(): col for col in expected_columns}
+    normalized_required = {col.lower() for col in required_columns}
+
+    header_map: typing.Dict[str, typing.Union[int, None]] = {}
+    found = set()
+
+    for col in expected_columns:
+        header_map[col] = None
+
+    for i, part in enumerate(parts):
+        normalized = part.lower()
+
+        if (normalized in normalized_expected):
+            header_map[normalized_expected[normalized]] = i
+            found.add(normalized)
+
+    if (normalized_required.issubset(found)):
+        return header_map
+
+    return None

--- a/lms/util/tsv_test.py
+++ b/lms/util/tsv_test.py
@@ -1,0 +1,367 @@
+import edq.testing.unittest
+import edq.util.dirent
+
+import lms.util.tsv
+
+def _write_temp(content: str) -> str:
+    """ Write content to a temp file and return its path. """
+
+    path = edq.util.dirent.get_temp_path(suffix = '.tsv')
+    with open(path, 'w', encoding = edq.util.dirent.DEFAULT_ENCODING) as f:
+        f.write(content)
+
+    return path
+
+def _remove_temp(path: str) -> None:
+    """ Remove a temp file if it exists. """
+
+    edq.util.dirent.remove(path)
+
+class TestParseTsvRows(edq.testing.unittest.BaseTest):
+    """ Tests for parse_tsv_rows — raw row parsing with no header logic. """
+
+    def test_returns_all_non_blank_rows(self):
+        """ Blank lines are skipped and remaining rows are returned. """
+
+        path = _write_temp("foo\tbar\n\nbaz\tqux\n")
+        try:
+            rows = lms.util.tsv.parse_tsv_rows(path)
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0].parts, ['foo', 'bar'])
+            self.assertEqual(rows[1].parts, ['baz', 'qux'])
+        finally:
+            _remove_temp(path)
+
+    def test_only_blank_lines_returns_no_rows(self):
+        """ A file containing only blank lines produces an empty list. """
+
+        path = _write_temp("\n\n\n")
+        try:
+            rows = lms.util.tsv.parse_tsv_rows(path)
+            self.assertEqual(rows, [])
+        finally:
+            _remove_temp(path)
+
+    def test_empty_file_returns_no_rows(self):
+        """ An empty file produces an empty list. """
+
+        path = _write_temp('')
+        try:
+            rows = lms.util.tsv.parse_tsv_rows(path)
+            self.assertEqual(rows, [])
+        finally:
+            _remove_temp(path)
+
+    def test_tracks_real_and_effective_line_numbers(self):
+        """ lineno counts blank lines; effective_lineno does not. """
+
+        path = _write_temp("foo\tbar\n\nbaz\tqux\n")
+        try:
+            rows = lms.util.tsv.parse_tsv_rows(path)
+            self.assertEqual(rows[0].lineno, 1)
+            self.assertEqual(rows[0].effective_lineno, 1)
+            self.assertEqual(rows[1].lineno, 3)
+            self.assertEqual(rows[1].effective_lineno, 2)
+        finally:
+            _remove_temp(path)
+
+    def test_raise_error_includes_line_context(self):
+        """ raise_error includes both line numbers and the caller's message. """
+
+        path = _write_temp("foo\tbar\n")
+        try:
+            rows = lms.util.tsv.parse_tsv_rows(path)
+            with self.assertRaises(ValueError) as ctx:
+                rows[0].raise_error("something went wrong")
+            self.assertIn("Line 1", str(ctx.exception))
+            self.assertIn("effective 1", str(ctx.exception))
+            self.assertIn("something went wrong", str(ctx.exception))
+        finally:
+            _remove_temp(path)
+
+class TestLoadTsvTable(edq.testing.unittest.BaseTest):
+    """ Tests for load_tsv_table — header detection, column mapping. """
+
+    def test_with_header(self):
+        """ Header row is detected and removed from data rows. """
+
+        path = _write_temp("group\tuser\nGroup A\tUser 1\nGroup B\tUser 2\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.headers, ['group', 'user'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+                {'group': 'Group B', 'user': 'User 2'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_without_header(self):
+        """ Columns are mapped positionally when no header row is present. """
+
+        path = _write_temp("Group A\tUser 1\nGroup B\tUser 2\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertIsNone(tsv.headers)
+            self.assertEqual(tsv.header_map, {'group': 0, 'user': 1})
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+                {'group': 'Group B', 'user': 'User 2'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_out_of_order_columns(self):
+        """ Columns in the file in a different order are mapped correctly. """
+
+        path = _write_temp("user\tgroup\nUser 1\tGroup A\nUser 2\tGroup B\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.headers, ['user', 'group'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+                {'group': 'Group B', 'user': 'User 2'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_extra_columns_are_ignored(self):
+        """ Columns not in expected_columns are silently ignored. """
+
+        content = (
+            "group\textra\tuser\n"
+            "Group A\tfoo\tUser 1\n"
+            "Group B\tbar\tUser 2\n"
+        )
+        path = _write_temp(content)
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.headers, ['group', 'extra', 'user'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+                {'group': 'Group B', 'user': 'User 2'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_missing_column_defaults_to_empty_string(self):
+        """ A column in expected_columns absent from the file gives ''. """
+
+        path = _write_temp("user\nUser 1\nUser 2\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path, ['group', 'user'], required_columns = ['user'],
+            )
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': '', 'user': 'User 1'},
+                {'group': '', 'user': 'User 2'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_header_present_but_no_expected_columns_match(self):
+        """ First row matches no expected columns; treated as data row. """
+
+        path = _write_temp("foo\tbar\nGroup A\tUser 1\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertIsNone(tsv.headers)
+            self.assertEqual(len(tsv.rows), 2)
+        finally:
+            _remove_temp(path)
+
+    def test_header_matching_is_case_insensitive(self):
+        """ Header names match regardless of case. """
+
+        path = _write_temp("GROUP\tUSER\nGroup A\tUser 1\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.headers, ['GROUP', 'USER'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_skip_rows(self):
+        """ Leading rows are discarded before any header or data processing. """
+
+        content = "Garbage\nMore Garbage\ngroup\tuser\nGroup A\tUser 1\n"
+        path = _write_temp(content)
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path, ['group', 'user'], skip_rows = 2,
+            )
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_blank_lines_are_skipped(self):
+        """ Blank lines between data rows are ignored. """
+
+        content = "group\tuser\n\nGroup A\tUser 1\n\nGroup B\tUser 2\n"
+        path = _write_temp(content)
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+                {'group': 'Group B', 'user': 'User 2'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_partial_row_fills_missing_columns_with_empty_string(self):
+        """ A row shorter than the header gives '' for missing columns. """
+
+        path = _write_temp("group\tuser\tcomment\nGroup A\tUser 1\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path, ['group', 'user', 'comment'],
+            )
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1', 'comment': ''},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_interpret_headers_false_skips_header_detection(self):
+        """ With interpret_headers=False columns are always positional. """
+
+        path = _write_temp("group\tuser\nGroup A\tUser 1\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path, ['group', 'user'], interpret_headers = False,
+            )
+            self.assertIsNone(tsv.headers)
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'group', 'user': 'user'},
+                {'group': 'Group A', 'user': 'User 1'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_empty_file_returns_empty_tsv(self):
+        """ An empty file produces a TSVFile with no rows. """
+
+        path = _write_temp('')
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertIsNone(tsv.headers)
+            self.assertEqual(tsv.rows, [])
+        finally:
+            _remove_temp(path)
+
+    def test_empty_expected_columns_raises(self):
+        """ Passing an empty expected_columns raises ValueError. """
+
+        path = _write_temp("group\tuser\n")
+        try:
+            with self.assertRaises(ValueError):
+                lms.util.tsv.load_tsv_table(path, [])
+        finally:
+            _remove_temp(path)
+
+    def test_required_columns_not_in_expected_raises(self):
+        """ required_columns with names outside expected_columns raises. """
+
+        path = _write_temp("group\tuser\n")
+        try:
+            with self.assertRaises(ValueError):
+                lms.util.tsv.load_tsv_table(
+                    path,
+                    ['group', 'user'],
+                    required_columns = ['group', 'user', 'comment'],
+                )
+        finally:
+            _remove_temp(path)
+
+    def test_required_columns_subset_detects_header(self):
+        """ Header detected when all required columns match. """
+
+        path = _write_temp("user\tscore\nUser 1\t95\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path,
+                ['user', 'score', 'comment'],
+                required_columns = ['user', 'score'],
+            )
+            self.assertEqual(tsv.headers, ['user', 'score'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'user': 'User 1', 'score': '95', 'comment': ''},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_missing_column_out_of_order(self):
+        """ Missing column, remaining columns out of order, maps correctly. """
+
+        path = _write_temp("user\tgroup\nUser 1\tGroup A\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path,
+                ['group', 'user', 'comment'],
+                required_columns = ['group', 'user'],
+            )
+            self.assertEqual(tsv.headers, ['user', 'group'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1', 'comment': ''},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_extra_columns_out_of_order(self):
+        """ Extra and out-of-order columns in header are handled correctly. """
+
+        content = (
+            "user\textra\tgroup\n"
+            "User 1\tfoo\tGroup A\n"
+        )
+        path = _write_temp(content)
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.headers, ['user', 'extra', 'group'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+            ])
+        finally:
+            _remove_temp(path)
+
+    def test_negative_skip_rows_raises(self):
+        """ A negative skip_rows value raises ValueError. """
+
+        path = _write_temp("group\tuser\n")
+        try:
+            with self.assertRaises(ValueError):
+                lms.util.tsv.load_tsv_table(
+                    path, ['group', 'user'], skip_rows = -1,
+                )
+        finally:
+            _remove_temp(path)
+
+    def test_required_columns_case_insensitive_validation(self):
+        """ required_columns validation is case-insensitive. """
+
+        path = _write_temp("GROUP\tUSER\nGroup A\tUser 1\n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(
+                path,
+                ['group', 'user'],
+                required_columns = ['Group', 'User'],
+            )
+            self.assertEqual(tsv.headers, ['GROUP', 'USER'])
+        finally:
+            _remove_temp(path)
+
+    def test_parts_are_stripped_of_whitespace(self):
+        """ Leading and trailing whitespace in field values is stripped. """
+
+        path = _write_temp("group\tuser\n  Group A  \t  User 1  \n")
+        try:
+            tsv = lms.util.tsv.load_tsv_table(path, ['group', 'user'])
+            self.assertEqual(tsv.to_dicts(), [
+                {'group': 'Group A', 'user': 'User 1'},
+            ])
+        finally:
+            _remove_temp(path)


### PR DESCRIPTION
Resolves #33.

This PR adds support for an optional header row that, when present, is automatically detected and used to drive column mapping — allowing columns in any order, missing optional columns, and extra columns to all be handled correctly.

## Changes

- `lms/util/tsv.py` — new shared utility with `read_tsv()` and `_parse_header()`. Automatically detects a header if any cell in the first row matches a known column name (case-insensitive). Falls back to positional ordering if no header is found.
- `lms/cli/courses/assignments/scores/upload.py` — refactored `_load_scores` to use `read_tsv` with `['user', 'score', 'comment']` as expected columns.
- `lms/cli/courses/groupsets/memberships/common.py` — refactored `load_group_memberships` to use `read_tsv` with `['group', 'user']` as expected columns.

All existing behavior and error messages are preserved unchanged.

## Corner Cases Covered

|                              | In Order | Out of Order |
|------------------------------|----------|--------------|
| All columns                  | ✅       | ✅           |
| Missing columns              | ✅       | ✅           |
| Extra columns                | ✅       | ✅           |
| No header (positional fallback) | ✅    | —            |

## Test Plan

New test fixtures added for each of the 6 header corner cases under `lms/backend/testdata/`. All existing tests pass.