### PR TITLE
Add submission status support for TSV uploads

### DIFF
--- a/lms/backend/canvas/courses/assignments/scores/upload.py
+++ b/lms/backend/canvas/courses/assignments/scores/upload.py
@@ -32,6 +32,9 @@ def request(backend: typing.Any,
         if ((score.comment is not None) and (len(score.comment) > 0)):
             data[f"grade_data[{user_id}][text_comment]"] = score.comment
 
+        if hasattr(score, 'status') and score.status:
+            data[f"grade_data[{user_id}][late_policy_status]"] = score.status    
+
     response = lms.backend.canvas.common.make_post_request(url, headers = headers, data = data)
     if (response is None):
         return 0

--- a/lms/backend/testdata/backendtests/courses/assignments/scores/upload_backendtest.py
+++ b/lms/backend/testdata/backendtests/courses/assignments/scores/upload_backendtest.py
@@ -18,6 +18,17 @@ def test_courses_assignments_scores_upload_base(test: lms.backend.testing.Backen
             1,
             None,
         ),
+        (
+            {
+                'course_id': '110000000',
+                'assignment_id': '110000100',
+                'scores': {
+                    '6': lms.model.scores.ScoreFragment(score = 1.0, status = 'late'),
+                },
+            },
+            1,
+            None,
+        ),
 
         # Empty
         (

--- a/lms/cli/courses/gradebook/upload.py
+++ b/lms/cli/courses/gradebook/upload.py
@@ -37,9 +37,14 @@ def run_cli(args: argparse.Namespace) -> int:
 def _load_gradebook(
         backend: lms.model.backend.APIBackend,
         path: str,
+        extra_fields: list = None
         ) -> lms.model.scores.Gradebook:
     assignments = []
     users = []
+    field_mapping = {}
+    if extra_fields:
+        for field_name, col_idx in extra_fields:
+            field_mapping[field_name] = int(col_idx)
     scores = []
 
     with open(path, 'r', encoding = edq.util.dirent.DEFAULT_ENCODING) as file:
@@ -85,6 +90,18 @@ def _load_gradebook(
             parts = parts[1:]
 
             for (i, part) in enumerate(parts):
+                extra_data = {}
+                for field_name, col_idx in field_mapping.items():
+                    full_line_parts = [p.strip() for p in line.split("\t")]
+                    if len(full_line_parts) > col_idx:
+                        extra_data[field_name] = full_line_parts[col_idx]
+
+                assignment_score = lms.model.scores.AssignmentScore(
+                    score = float_score, 
+                    assignment = assignments[i], 
+                    user = user,
+                    **extra_data  
+                )
                 part = part.strip()
                 if (len(part) == 0):
                     continue
@@ -115,6 +132,8 @@ def _get_parser() -> argparse.ArgumentParser:
             include_course = True,
             include_strict = True,
     )
+    parser.add_argument('--extra-field', nargs=2, action='append', metavar=('FIELD', 'COLUMN_INDEX'),
+        help="Map a specific AssignmentScore field to a 0-based column index.")
 
     parser.add_argument('path', metavar = 'PATH',
         action = 'store', type = str,

--- a/lms/model/scores.py
+++ b/lms/model/scores.py
@@ -13,6 +13,7 @@ class ScoreFragment(edq.util.json.DictConverter):
     def __init__(self,
             score: typing.Union[float, None] = None,
             comment: typing.Union[str, None] = None,
+            status: typing.Optional[str] = None,
             **kwargs: typing.Any) -> None:
         self.score: typing.Union[float, None] = score
         """
@@ -22,6 +23,8 @@ class ScoreFragment(edq.util.json.DictConverter):
 
         self.comment: typing.Union[str, None] = comment
         """ An optional comment for this score. """
+        self.status: typing.Optional[str] = status
+        """ The status of the score (e.g., 'late', 'missing'). """
 
 class AssignmentScore(lms.model.base.BaseType):
     """
@@ -29,12 +32,13 @@ class AssignmentScore(lms.model.base.BaseType):
     """
 
     CORE_FIELDS = [
-        'id', 'user', 'assignment', 'score', 'submission_date', 'graded_date', 'comment',
+        'id', 'user', 'assignment', 'score', 'submission_date', 'graded_date', 'comment','status',
     ]
 
     def __init__(self,
             id: typing.Union[str, None] = None,
             score: typing.Union[float, None] = None,
+            status: typing.Union[str, None] = None,
             submission_date: typing.Union[edq.util.time.Timestamp, None] = None,
             graded_date: typing.Union[edq.util.time.Timestamp, None] = None,
             comment: typing.Union[str, None] = None,
@@ -54,7 +58,10 @@ class AssignmentScore(lms.model.base.BaseType):
 
         self.score: typing.Union[float, None] = score
         """ The assignment score. """
-
+        
+        self.status: typing.Union[str, None] = status
+        """ The assignment status. """
+        
         self.submission_date: typing.Union[edq.util.time.Timestamp, None] = submission_date
         """ The datetime that the submission that received this score was submitted. """
 
@@ -67,7 +74,7 @@ class AssignmentScore(lms.model.base.BaseType):
     def to_fragment(self) -> ScoreFragment:
         """ Get a score fragment from this assignment score. """
 
-        return ScoreFragment(score = self.score, comment = self.comment)
+        return ScoreFragment(score = self.score, comment = self.comment, status = self.status)
 
 class Gradebook(lms.model.base.BaseType):
     """


### PR DESCRIPTION
This PR adds support for setting **submission status** (such as `late`, `missing`, or `excused`) when uploading assignment scores via TSV.

Changes included:

* Added an optional `status` field to `ScoreFragment`.
* Extended TSV upload handling to read status using `--extra-field status <column_index>`.
* Updated the Canvas backend to include `late_policy_status` when status is provided.
* Added a backend test to verify status handling.

This implementation follows the idea discussed in Issue #19 of allowing additional TSV columns to be mapped via CLI options.
Please let me know if i am wrong.