### PR TITLE
Improve error message for missing LMS server configuration

### DIFF
--- a/lms/backend/instance.py
+++ b/lms/backend/instance.py
@@ -20,7 +20,12 @@ def get_backend(
     """
 
     if (server is None):
-        raise ValueError("No LMS server address provided.")
+        raise ValueError(
+    "No LMS server address provided.\n"
+    "Please provide server via config file or --server option.\n"
+    "Example config:\n"
+    '{ "server": "https://canvas.example.com", "token": "YOUR_TOKEN" }'
+)
 
     server = server.strip()
     if (not server.startswith('http')):


### PR DESCRIPTION

This PR improves the CLI error message shown when no LMS server configuration is provided.

Previously, the tool raised a validation error without clear guidance on how to resolve it.
This change enhances onboarding by providing actionable instructions and an example configuration snippet.

**Changes**

* Improved validation message in `lms/backend/instance.py`
* Added example configuration guidance

**Impact**

* Better first-run developer experience
* Reduced confusion during project setup
* Helps new contributors get started faster

Fixes #44 
